### PR TITLE
Merges the message to the json toplevel if it's a hash

### DIFF
--- a/lib/logging/layouts/parseable.rb
+++ b/lib/logging/layouts/parseable.rb
@@ -144,7 +144,12 @@ module Logging::Layouts
       code << layout.items.map {|name|
         "'#{name}' => #{Parseable::DIRECTIVE_TABLE[name]}"
       }.join(",\n")
-      code << "\n}\nMultiJson.encode(h) << \"\\n\"\nend\n"
+      code << "\n}\n"
+      code << "if h['message'].is_a? Hash\n"
+      code << "message_hash = h.delete('message')\n"
+      code << "h.merge!(message_hash)\n"
+      code << "end\n"
+      code << "MultiJson.encode(h) << \"\\n\"\nend\n"
 
       (class << layout; self end).class_eval(code, __FILE__, __LINE__)
     end


### PR DESCRIPTION
Normally a logline looks like this (formatted as json):

```
{"timestamp":"2023-05-31T18:51:08.531065Z","level":"INFO","logger":"Rails","message":"string message"}
```

But when we formats the message with lograge we add additional metadata to the log message. That data can either be passed as a hash or json to the log line.

```
{"timestamp":"2023-05-31T18:51:08.531065Z","level":"INFO","logger":"Rails","message": { "foo": "bar", message: "inner message string" } }
```

Mixing data type for the `message` field makes it very tricky to map it and index it properly in elastic search.

A solution is to instead pass the message as a json-string, which means that the field will always be a string. But then we have the problem of parsing the message.

Because of that I've made this little patch that merges the message to the top level if the message is a hash. This works since we blindly trust our code to not create a message hash that contains keys that conflicts with the top level. Then we get a message like this instead:

```
{"timestamp":"2023-05-31T18:51:08.531065Z","level":"INFO","logger":"Rails","foo":"bar","message":"inner message string"}
``` 

**NOTE: This PR only changes the json formatter. Other formatters works as before.**